### PR TITLE
[META] The existing compute logic doesn't work

### DIFF
--- a/product_variant_supplierinfo/models/product_product.py
+++ b/product_variant_supplierinfo/models/product_product.py
@@ -12,7 +12,7 @@ class ProductProduct(models.Model):
 
     seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids',
+        compute='compute_seller_ids',
         store=True)
     seller_delay = fields.Integer(
         related='seller_ids.delay',
@@ -35,15 +35,13 @@ class ProductProduct(models.Model):
         'product_id')
     tmpl_seller_ids = fields.Many2many(
         'product.supplierinfo',
-        compute='_compute_seller_ids',
+        compute='compute_seller_ids',
         store=True,)
 
     @api.multi
     @api.depends('product_tmpl_id.seller_ids.product_id')
-    def _compute_seller_ids(self):
+    def compute_seller_ids(self):
         for product in self:
             sellers = product.product_tmpl_id.seller_ids
-            product.tmpl_seller_ids = sellers.filtered(
-                lambda x: not x.product_id)
-            product.seller_ids = sellers.filtered(
-                lambda x: not x.product_id or x.product_id == product)
+            product.tmpl_seller_ids = sellers
+            product.seller_ids = sellers.filtered(lambda x: x.product_id == product)


### PR DESCRIPTION
for KFs use case, and I can't quite see how it worked before.
This change should require no force updates of computes on staging,
however a script is being run on dev-docker as we speak with this fix applied:
```
product = odoo.env['product.product']
products = product.search([])
print(products)
for prod in products:
    print("recomputing seller ids for product id {}".format(prod))
    product.browse(prod).compute_seller_ids()
```
This is required due to the compute not re-running after code change,
and it does not appear to be possible to drop a column which is a M2M, like
we would do if we wanted to  force re-compute any other field.